### PR TITLE
AV-69006: Add demo tenant network and router

### DIFF
--- a/rocky/installer.sh
+++ b/rocky/installer.sh
@@ -16,6 +16,7 @@ fi
 
 cp /root/files/demo-openrc.sh /root/
 cp /root/files/admin-openrc.sh /root/
+cp /root/files/aviuser-openrc.sh /root/
 source /root/admin-openrc.sh
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Add a private network and router in demo tenant.
Share the network with avilbaas tenant.

This is used to test the tenant VIP and FIP access in OpenStack using
non-admin privileges.