### PR TITLE
Fix docker image pull

### DIFF
--- a/docker-vm/create-docker-vm.sh
+++ b/docker-vm/create-docker-vm.sh
@@ -32,7 +32,7 @@ if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi
 export OS_INTERFACE=public
 export OS_IDENTITY_API_VERSION=3
 
-if [[ "$#" -ne 3 ]]; then
+if [[ "$#" -ne 5 ]]; then
     echo "Illegal number of parameters"
     exit 1
 fi
@@ -40,6 +40,8 @@ fi
 PREFIX=$1
 OS_VERSION=$2
 AVI_CONTROLLER_IP=$3
+DUSER=$4
+DPASS=$5
 VM_NAME="$PREFIX-docker-$OS_VERSION"
 USER_DATA_FILE="docker-vm-init-$OS_VERSION.sh"
 cp ./docker_vm_init-1604.sh ./$USER_DATA_FILE
@@ -47,6 +49,8 @@ cp ./docker_vm_init-1604.sh ./$USER_DATA_FILE
 # Replace OS_VERSION and Avi Controller IP
 sed -i "s/OPENSTACK_RELEASE/$OS_VERSION/g" ./$USER_DATA_FILE
 sed -i "s/AVI_CONTROLLER_IP/$AVI_CONTROLLER_IP/g" ./$USER_DATA_FILE
+sed -i "s/DUSER/$DUSER/g" ./$USER_DATA_FILE
+sed -i "s/DPASS/$DPASS/g" ./$USER_DATA_FILE
 openstack server delete $VM_NAME
 sleep 10
 netid=`openstack network show avimgmt -c 'id' --format 'value'`
@@ -57,7 +61,8 @@ openstack server create --flavor m1.large \
     --nic net-id=$netid \
     $VM_NAME
 
-echo "Waiting for VM to come up (20s)..."
-sleep 60
+WAITTIME=60
+echo "Waiting for VM to come up $WAITTIME secs..."
+sleep $WAITTIME
 
 openstack server show $VM_NAME -c addresses -f value | cut -d'=' -f2 >| /tmp/docker-vm-ip

--- a/docker-vm/docker_vm_init-1604.sh
+++ b/docker-vm/docker_vm_init-1604.sh
@@ -40,6 +40,8 @@ apt-get -y install docker-ce docker-ce-cli containerd.io
 
 VERSION=OPENSTACK_RELEASE
 ENS3_IP=$(ifconfig ens3 | awk '/inet addr/{print $2}' | cut -d':' -f2)
+DOCKER_USER=DUSER
+DOCKER_PASSWD=DPASS
 
 IMAGE=""
 if [[ $VERSION == "liberty" ]]; then
@@ -55,6 +57,8 @@ if [[ $VERSION < "ocata" ]]; then
     SCRIPT="/root/files/startup"
 fi
 
+echo $DOCKER_PASSWD | docker login --username=$DOCKER_USER --password-stdin
+
 docker run --name=$VERSION-heat -p 9292:9292 -p 35357:35357 \
         -p 8774:8774 -p 5000:5000 -p 8004:8004 -p 9696:9696 \
         -p 8000:8000 \
@@ -69,3 +73,5 @@ docker run --name=$VERSION-heat -p 9292:9292 -p 35357:35357 \
 
 sleep 20
 docker logs $VERSION-heat
+
+docker logout


### PR DESCRIPTION
Docker image pull is failing with rate limit error.

Login into docker hub before pull seems to fix the issue for now.