### PR TITLE
Fix flavor and resource allocation ratio

### DIFF
--- a/ocata/nova.conf
+++ b/ocata/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/others/create-se-flavor.sh
+++ b/others/create-se-flavor.sh
@@ -4,4 +4,4 @@ set -x
 source /root/files/admin-openrc.sh
 
 openstack flavor create m1.vm --id auto --public --ram 1024 --disk 10 --vcpus 1
-openstack flavor create m1.se --id auto --public --ram 1024 --disk 20 --vcpus 1
+openstack flavor create m1.se --id auto --public --ram 2048 --disk 20 --vcpus 1

--- a/pike/nova.conf
+++ b/pike/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/queens/nova.conf
+++ b/queens/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/rocky/nova.conf
+++ b/rocky/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/stein/nova.conf
+++ b/stein/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/train/nova.conf
+++ b/train/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]

--- a/ussuri/nova.conf
+++ b/ussuri/nova.conf
@@ -4,6 +4,9 @@ dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=true
 state_path=/var/lib/nova
 enabled_apis=osapi_compute,metadata
+cpu_allocation_ratio = 1.0
+ram_allocation_ratio = 1.0
+disk_allocation_ratio = 1.0
 [barbican]
 [cache]
 [cells]


### PR DESCRIPTION
Fix flavor of SE to have 2GB RAM as required by Avi 20.1.2+

Make sure the resource allocation is not over subscribed. Over
subscription makes SE slower.