### PR TITLE
AV-110287 Fix docker-vm create script

### DIFF
--- a/docker-vm/create-docker-vm.sh
+++ b/docker-vm/create-docker-vm.sh
@@ -56,4 +56,6 @@ WAITTIME=60
 echo "Waiting for VM to come up $WAITTIME secs..."
 sleep $WAITTIME
 
-openstack server show $VM_NAME -c addresses -f value | cut -d'=' -f2 >| /tmp/docker-vm-ip
+openstack server show $VM_NAME -c addresses -f json | \
+    python3 -c "import sys, json; print(json.load(sys.stdin)['addresses']['avimgmt'][0])" \
+    | tr -d '\n' >| /tmp/docker-vm-ip


### PR DESCRIPTION
Use json as output format and parse it to find the VM IP address.
Previously, we were depending on output of openstack command with format
of value, however, it is no longer returning value expected format.